### PR TITLE
added mlcn project

### DIFF
--- a/_projects/mlcn.md
+++ b/_projects/mlcn.md
@@ -1,0 +1,61 @@
+---
+title: Machine Learning for the Cognitive Neurosciences
+subtitle: Teaching workshop for applying ML methods to neuroscience
+status: active
+layout: default
+---
+
+From the 18th to 22nd of January, 2021,  the NeuroDataScience ORIGAMI lab, the McGill Centre for Integrative Neuroscience,  and HBHL’s NeuroHub will hold a workshop entitled “Machine Learning for the Cognitive Neurosciences”, whose objective will be to introduce researchers to both the conceptual and practical rudiments of machine learning as applied to neuroimaging. See preliminary schedule below.
+
+Though attendees are expected to have a general familiarity with brain imaging and conventional statistical analyses, the first two days introduce attendees to the software environment that will serve for the practical exercises during the workshop, including some basics of the Linux command line (Bash), Git, the Python programming language, and several Python-based packages for scientific computing, courtesy of Calcul Québec.
+
+The core content will be presented over the remaining days. Our first speaker, Dr. Tal Yarkoni (University of Texas at Austin) will discuss the scientific applications of machine learning in brain imaging. Our second speaker, Dr. Ella Gabitov (McGill University), will present on the explanatory power and limitations of machine learning when applied to cognitive neuroscience. Throughout the workshop, hands-on tutorials will be presented by Alexandre Hutton (ORIGAMI, McGill), which will focus on giving participants an understanding of core concepts and common practices in machine learning.
+
+### Logistic Summary:
+Dates: January 18-22, 2021  
+Cost: $10  
+Venue: The workshop will be held online over Zoom.  
+Registration: The link will be made available following the announcement.  
+Info: [ORIGAMI website](/projects/mlcn.html)  
+Questions: Contact us via email: info.mlcn@gmail.com  
+
+
+### Organizers & Contributors:  
+**Alexandre Hutton**, MNI, McGill University  
+**Paule-Joanne Toussaint**, MNI, McGill University  
+**Patrick Bermudez**, MNI, McGill University  
+**Alan C. Evans**, MCIN, McGill University  
+**Jean-Baptiste Poline**, MNI, McGill University  
+    
+NeuroDataScience: ORIGAMI  
+McGill Centre for Integrative Neuroscience  
+HBHL-NeuroHub  
+
+### Preliminary Schedule:  
+**Day 1** (Monday)  
+_Group 1_:  
+09:00 – 12:00 Calcul Québec – Introduction to Python and other basics  
+_Group 2_:  
+09:00 - 10:00 Linux command line: Bash.  
+10:00 - 11:00 ORIGAMI - Git & version control  
+  
+**Day 2** (Tuesday)  
+_Group 1_:  
+09:00 - 10:00 Linux command line: Bash.  
+10:00 - 11:00 ORIGAMI - Git & version control  
+_Group 2_:  
+09:00 – 12:00 Calcul Québec – Introduction to Python and other basics  
+  
+**Day 3** (Wednesday)  
+09:00 – 10:30 Dr. Tal Yarkoni – “Machine Learning as Applied to Neuroimaging”  
+10:30 – 12:30 Alexandre Hutton – Hands-on ML: dataset handling, sklearn/nilearn, estimators & models, model evaluation  
+13:30 – 16:00 Practical exercises  
+  
+**Day 4** (Thursday)  
+09:00 – 12:30 Alexandre Hutton – Hands-on ML: cross-validation,  ROC & AUC, visualization, evaluation metrics  
+13:30 – 16:00 Practical exercises  
+  
+**Day 5** (Friday)  
+09:00 – 10:00 Dr. Ella Gabitov – “The elephant in the room: to explain or to predict, that is the question”  
+10:00 – 12:30 Alexandre Hutton – Hands-on ML: confounds. model interpretation (and lack thereof)  
+13:30 – 16:30 Practical exercises, data clinic  

--- a/_projects/mlcn.md
+++ b/_projects/mlcn.md
@@ -1,6 +1,6 @@
 ---
 title: Machine Learning for the Cognitive Neurosciences
-subtitle: Teaching workshop for applying ML methods to neuroscience
+description: Teaching workshop for applying ML methods to neuroscience
 status: active
 layout: default
 ---


### PR DESCRIPTION
Added ML workshop info under 'Projects'. Associated people intentionally left blank since 2 organizers are outside the lab. Will be switched to 'inactive' after Jan. 22, 2021 for posterity.