### PR TITLE
[FIX] make sure favicon is displayed

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -11,6 +11,7 @@
         <link rel="stylesheet"
               href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
         <link rel="stylesheet" href="{{ site.base }}/css/group.css">
+        <link rel="icon" type="image/x-icon" href="{{ site.base }}/img/other/favicon.ico">
     </head>
     <body>
         <div class="container">


### PR DESCRIPTION
relates to #30 

without on the left and with on the right

![Screenshot from 2023-05-09 15-06-58](https://github.com/neurodatascience/neurodatascience.github.io/assets/6961185/40146155-19f6-488d-9ba8-69f9d4f79ff5)

not sure if this is the final favicon so won't merge just yet
